### PR TITLE
fix: prevent duplicate Codex installs and respect user's package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 dist/
 docs
 .ck
+.spezi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+- Installer respects PATH-first for Codex: skips installing `@openai/codex` when `codex` is already available on PATH.
+- Global Node installs now honor the user’s package manager without cross-installs:
+  - Prefer pnpm (only when its global bin is configured).
+  - Use npm when pnpm is not present.
+  - Never use yarn global to avoid surprises.
+- When pnpm is detected but its global bin is not configured, the installer skips global Node installs with a clear warning (suggests `pnpm setup`) instead of falling back and causing duplicates.
+
+### Added
+- `doctor` now prints all `codex` candidates found on PATH (“--- codex paths ---”) to help diagnose duplicates.
 
 ## [0.1.5] - 2025-11-09
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -10,6 +10,14 @@ for c in node npm codex ast-grep fd fdfind rg fzf jq yq difft delta code; do
   check "$c"
 done
 
+echo "--- codex paths ---"
+if command -v codex >/dev/null 2>&1; then
+  # Show all codex candidates on PATH (guarded to avoid exiting with -e)
+  type -a codex 2>/dev/null || which -a codex 2>/dev/null || command -v codex 2>/dev/null
+else
+  echo "codex not found on PATH"
+fi
+
 echo "--- git ---"
 echo "diff.external = $(git config --global --get diff.external || echo "(none)")"
 echo "difftool.difftastic.cmd = $(git config --global --get difftool.difftastic.cmd || echo "(none)")"


### PR DESCRIPTION
## Problem

When users installed `codex` via pnpm, `codex-1up` would still install it again via npm, creating duplicate global installs. This caused:
- Version drift between npm and pnpm installs
- Confusion about which `codex` binary is actually used
- Violation of user's package manager choice

## Solution

1. **PATH-first skip**: If `codex` is already on PATH, we skip installing/updating it entirely
2. **Respect user's package manager**: Detect and use the same PM the user prefers (pnpm → npm, no yarn fallback)
3. **Avoid cross-installs**: If pnpm is present but not configured for globals, we skip with a warning rather than falling back to npm
4. **Enhanced diagnostics**: `codex-1up doctor` now shows all `codex` binaries on PATH to help identify duplicates

## Changes

- `installNpmGlobals.ts`: Added PATH-first check for codex, PM detection and selection logic
- `utils.ts`: Added `detectNodePackageManager()` and `chooseNodePmForGlobal()` helpers
- `doctor.sh`: Added "codex paths" section showing all binaries on PATH
- `CHANGELOG.md`: Documented the fix

## Testing

- All existing tests pass (`vitest --run`)
- Verified PATH-first skip works correctly
- Verified pnpm-only behavior when pnpm is configured
- Verified fallback to npm only when pnpm is not present

## Platform tested

macOS 24.6.0