### PR TITLE
refactor: remove model_reasoning_summary and model_verbosity from yolo profile

### DIFF
--- a/cli/src/installers/writeCodexConfig.ts
+++ b/cli/src/installers/writeCodexConfig.ts
@@ -40,8 +40,6 @@ const PROFILE_DEFAULTS: Record<Profile, ProfileDefaults> = {
       ['sandbox_mode', '"danger-full-access"'],
       ['model', '"gpt-5.1-codex"'],
       ['model_reasoning_effort', '"medium"'],
-      ['model_reasoning_summary', '"detailed"'],
-      ['model_verbosity', '"high"'],
       ['tool_output_token_limit', '25000']
     ],
     features: [['web_search_request', 'true']]

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -64,8 +64,6 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 model = "gpt-5.1-codex"
 model_reasoning_effort = "medium"
-model_reasoning_summary = "detailed"
-model_verbosity = "high"
 tool_output_token_limit = 25000
 [profiles.yolo.features]
 web_search_request = true


### PR DESCRIPTION
Removes model_reasoning_summary and model_verbosity settings from the yolo profile configuration in both the template and installer code.