### PR TITLE
chore: update default Codex model to gpt-5.2-codex and migrate deprecated config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Default Codex model is now `gpt-5.2-codex` in the unified config template and installer-written profiles.
+- Migrate deprecated `enable_experimental_windows_sandbox` to `[features].experimental_windows_sandbox` when patching `~/.codex/config.toml`.
+- Migrate deprecated root-level feature booleans (e.g. `experimental_use_unified_exec_tool`) into `[features]` when patching `~/.codex/config.toml`.
+
 ## [0.3.4] - 2025-12-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ codex-1up install
 
 | Profile | Model | Sandbox | Description |
 | --- | --- | --- | --- |
-| balanced (default) | gpt-5.2 | workspace-write | Approvals on-request; web search on. Standard for everyday use. |
-| safe | gpt-5.2 | read-only | Approvals on-failure; web search off. Maximum security for critical repos. |
-| yolo | gpt-5.2 | danger-full-access | Never ask for approvals; high reasoning; optimized for long autonomous sessions. ⚠️ **Warning:** Grants full system access. |
+| balanced (default) | gpt-5.2-codex | workspace-write | Approvals on-request; web search on. Standard for everyday use. |
+| safe | gpt-5.2-codex | read-only | Approvals on-failure; web search off. Maximum security for critical repos. |
+| yolo | gpt-5.2-codex | danger-full-access | Never ask for approvals; high reasoning; optimized for long autonomous sessions. ⚠️ **Warning:** Grants full system access. |
 
 Switch profiles anytime: `codex --profile <name>` for a session, or `codex-1up config set-profile <name>` to persist.
 

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -139,14 +139,14 @@ export const installCommand = defineCommand({
           'Profiles:',
           '  • Balanced: on-request approvals, workspace-write sandbox, web search on.',
           '  • Safe: on-failure approvals, read-only sandbox, web search off.',
-          '  • YOLO: never approvals, danger-full-access, gpt-5.2, high reasoning.'
+          '  • YOLO: never approvals, danger-full-access, gpt-5.2-codex, high reasoning.'
         ].join('\n'))
         const profileResponse = await p.select({
           message: 'Choose a Codex profile to install',
           options: [
             { label: 'Balanced (recommended)', value: 'balanced', hint: 'on-request approvals · workspace-write · web search on' },
             { label: 'Safe', value: 'safe', hint: 'on-failure approvals · read-only · web search off' },
-            { label: 'YOLO', value: 'yolo', hint: 'never approvals · danger-full-access · gpt-5.2' },
+            { label: 'YOLO', value: 'yolo', hint: 'never approvals · danger-full-access · gpt-5.2-codex' },
             ...(profileScope === 'single' ? [{ label: 'Skip (no profile changes)', value: 'skip' as const }] : [])
           ],
           initialValue: initialProfileValue(currentProfile) as any

--- a/cli/src/installers/writeCodexConfig.ts
+++ b/cli/src/installers/writeCodexConfig.ts
@@ -14,7 +14,7 @@ const PROFILE_DEFAULTS: Record<Profile, ProfileDefaults> = {
     root: [
       ['approval_policy', '"on-request"'],
       ['sandbox_mode', '"workspace-write"'],
-      ['model', '"gpt-5.2"'],
+      ['model', '"gpt-5.2-codex"'],
       ['model_reasoning_effort', '"medium"'],
       ['model_reasoning_summary', '"concise"']
     ],
@@ -28,7 +28,7 @@ const PROFILE_DEFAULTS: Record<Profile, ProfileDefaults> = {
     root: [
       ['approval_policy', '"on-failure"'],
       ['sandbox_mode', '"read-only"'],
-      ['model', '"gpt-5.2"'],
+      ['model', '"gpt-5.2-codex"'],
       ['model_reasoning_effort', '"medium"'],
       ['model_reasoning_summary', '"concise"']
     ],
@@ -38,7 +38,7 @@ const PROFILE_DEFAULTS: Record<Profile, ProfileDefaults> = {
     root: [
       ['approval_policy', '"never"'],
       ['sandbox_mode', '"danger-full-access"'],
-      ['model', '"gpt-5.2"'],
+      ['model', '"gpt-5.2-codex"'],
       ['model_reasoning_effort', '"high"'],
       ['model_reasoning_summary', '"detailed"']
     ],
@@ -53,8 +53,10 @@ export async function writeCodexConfig(ctx: InstallerContext): Promise<void> {
   await fs.ensureDir(path.dirname(cfgPath))
   const exists = await fs.pathExists(cfgPath)
   const initial = exists ? await fs.readFile(cfgPath, 'utf8') : HEADER_COMMENT
-  const editor = new TomlEditor(initial)
-  let touched = false
+  const migratedWindowsSandbox = migrateExperimentalWindowsSandboxFlag(initial)
+  const migratedLegacyFeatures = migrateLegacyRootFeatureFlags(migratedWindowsSandbox.toml)
+  const editor = new TomlEditor(migratedLegacyFeatures.toml)
+  let touched = migratedWindowsSandbox.changed || migratedLegacyFeatures.changed
 
   touched = applyProfile(editor, ctx.options.profileScope, ctx.options.profile, ctx.options.profileMode) || touched
   touched = applyDefaultProfile(editor, ctx.options.profile, ctx.options.setDefaultProfile) || touched
@@ -278,4 +280,189 @@ function formatTableSeparator(text: string): string {
   if (!out.endsWith('\n')) out += '\n'
   if (!out.endsWith('\n\n')) out += '\n'
   return out
+}
+
+function migrateExperimentalWindowsSandboxFlag(toml: string): { toml: string; changed: boolean } {
+  // Codex CLI v0.74 deprecates `enable_experimental_windows_sandbox` in favor of
+  // `[features].experimental_windows_sandbox`.
+  const OLD_KEY = 'enable_experimental_windows_sandbox'
+  const NEW_KEY = 'experimental_windows_sandbox'
+
+  if (!toml.includes(OLD_KEY)) return { toml, changed: false }
+
+  const lines = toml.split(/\r?\n/)
+  let currentTable = ''
+
+  const isRelevantTable = (table: string) =>
+    table === 'features' || /^profiles\.[^.]+\.features$/.test(table)
+
+  // First pass: find which relevant tables already define the new key.
+  const tablesWithNewKey = new Set<string>()
+  for (const line of lines) {
+    const table = line.match(/^\s*\[([^\]]+)\]\s*$/)
+    if (table) {
+      currentTable = table[1].trim()
+      continue
+    }
+    if (/^\s*#/.test(line)) continue
+    if (!isRelevantTable(currentTable)) continue
+    if (new RegExp(`^\\s*${NEW_KEY}\\s*=`).test(line)) tablesWithNewKey.add(currentTable)
+  }
+
+  // Second pass: rename/remove old key lines; also capture any legacy root-level setting.
+  currentTable = ''
+  let changed = false
+  let rootOldValue: string | undefined
+
+  const out: string[] = []
+  for (const line of lines) {
+    const table = line.match(/^\s*\[([^\]]+)\]\s*$/)
+    if (table) {
+      currentTable = table[1].trim()
+      out.push(line)
+      continue
+    }
+
+    if (!/^\s*#/.test(line)) {
+      if (currentTable === '') {
+        const m = line.match(new RegExp(`^\\s*${OLD_KEY}\\s*=\\s*(.+?)\\s*$`))
+        if (m) {
+          rootOldValue = m[1]
+          changed = true
+          continue // drop legacy root key
+        }
+      }
+
+      if (isRelevantTable(currentTable)) {
+        if (new RegExp(`^\\s*${OLD_KEY}\\s*=`).test(line)) {
+          if (tablesWithNewKey.has(currentTable)) {
+            changed = true
+            continue // new key already exists; remove deprecated one
+          }
+          out.push(line.replace(new RegExp(`^(\\s*)${OLD_KEY}(\\s*=\\s*)`), `$1${NEW_KEY}$2`))
+          changed = true
+          continue
+        }
+      }
+    }
+
+    out.push(line)
+  }
+
+  let next = out.join('\n')
+
+  // If the legacy key was set at root, migrate it into [features] unless already set there.
+  if (rootOldValue !== undefined) {
+    const featuresRange = findTableRange(next, 'features')
+    const alreadySetInFeatures = (() => {
+      if (!featuresRange) return false
+      const block = next.slice(featuresRange.start, featuresRange.end)
+      return new RegExp(`^\\s*${NEW_KEY}\\s*=`,'m').test(block)
+    })()
+
+    if (!alreadySetInFeatures) {
+      const line = `${NEW_KEY} = ${rootOldValue}`
+      if (featuresRange) {
+        // Insert at end of the [features] table.
+        const before = next.slice(0, featuresRange.end)
+        const after = next.slice(featuresRange.end)
+        const needsLeadNl = before.length > 0 && !before.endsWith('\n')
+        const needsTrailNl = after.length > 0 && !after.startsWith('\n')
+        next = before + `${needsLeadNl ? '\n' : ''}${line}\n${needsTrailNl ? '\n' : ''}` + after
+      } else {
+        // No [features] table exists; append one.
+        const sep = next.length === 0 ? '' : formatTableSeparator(next)
+        next = sep + `[features]\n${line}\n`
+      }
+      changed = true
+    }
+  }
+
+  return { toml: next, changed }
+}
+
+function migrateLegacyRootFeatureFlags(toml: string): { toml: string; changed: boolean } {
+  // Codex CLI deprecated a number of root-level booleans in favor of [features].*
+  // Keep this list intentionally small and high-confidence.
+  const MAPPINGS: Array<{ oldKey: string; newKey: string }> = [
+    { oldKey: 'experimental_use_exec_command_tool', newKey: 'streamable_shell' },
+    { oldKey: 'experimental_use_unified_exec_tool', newKey: 'unified_exec' },
+    { oldKey: 'experimental_use_rmcp_client', newKey: 'rmcp_client' },
+    { oldKey: 'include_apply_patch_tool', newKey: 'apply_patch_freeform' }
+  ]
+
+  const hasAny = MAPPINGS.some(m => toml.includes(m.oldKey))
+  if (!hasAny) return { toml, changed: false }
+
+  function parseBoolRhs(rhs: string): string | undefined {
+    const trimmed = rhs.trim()
+    const m = /^(true|false)\b/i.exec(trimmed)
+    return m ? m[1].toLowerCase() : (trimmed || undefined)
+  }
+
+  const lines = toml.split(/\r?\n/)
+  let currentTable = ''
+
+  const wanted: Record<string, string> = {}
+  const out: string[] = []
+  let changed = false
+
+  for (const line of lines) {
+    const table = line.match(/^\s*\[([^\]]+)\]\s*$/)
+    if (table) {
+      currentTable = table[1].trim()
+      out.push(line)
+      continue
+    }
+
+    if (currentTable === '' && !/^\s*#/.test(line)) {
+      let migrated = false
+      for (const { oldKey, newKey } of MAPPINGS) {
+        const m = line.match(new RegExp(`^\\s*${escapeRegExp(oldKey)}\\s*=\\s*(.+?)\\s*$`))
+        if (m) {
+          const rhs = parseBoolRhs(m[1])
+          if (rhs !== undefined) wanted[newKey] = rhs
+          changed = true
+          migrated = true
+          break
+        }
+      }
+      if (migrated) continue
+    }
+
+    out.push(line)
+  }
+
+  let next = out.join('\n')
+  if (Object.keys(wanted).length === 0) return { toml: next, changed }
+
+  // Insert each migrated feature into [features] if not already present.
+  for (const { newKey } of MAPPINGS) {
+    const rhs = wanted[newKey]
+    if (rhs === undefined) continue
+
+    const featuresRange = findTableRange(next, 'features')
+    const alreadySetInFeatures = (() => {
+      if (!featuresRange) return false
+      const block = next.slice(featuresRange.start, featuresRange.end)
+      return new RegExp(`^\\s*${escapeRegExp(newKey)}\\s*=`, 'm').test(block)
+    })()
+
+    if (alreadySetInFeatures) continue
+
+    const line = `${newKey} = ${rhs}`
+    if (featuresRange) {
+      const before = next.slice(0, featuresRange.end)
+      const after = next.slice(featuresRange.end)
+      const needsLeadNl = before.length > 0 && !before.endsWith('\n')
+      const needsTrailNl = after.length > 0 && !after.startsWith('\n')
+      next = before + `${needsLeadNl ? '\n' : ''}${line}\n${needsTrailNl ? '\n' : ''}` + after
+    } else {
+      const sep = next.length === 0 ? '' : formatTableSeparator(next)
+      next = sep + `[features]\n${line}\n`
+    }
+    changed = true
+  }
+
+  return { toml: next, changed }
 }

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -2,7 +2,7 @@
 # Adjust to your liking. See Codex CLI docs for full options.
 
 # Core (root defaults)
-model = "gpt-5.2"
+model = "gpt-5.2-codex"
 approval_policy = "on-request"       # untrusted|on-failure|on-request|never
 sandbox_mode   = "workspace-write"   # read-only|workspace-write|danger-full-access
 profile = "balanced"                 # active profile: balanced|safe|yolo
@@ -33,14 +33,14 @@ apply_patch_freeform = false
 view_image_tool = true
 experimental_sandbox_command_assessment = false
 ghost_commit = false
-enable_experimental_windows_sandbox = false
+experimental_windows_sandbox = false
 
 # ---- Profiles (override only what differs from root) -----------------------
 
 [profiles.balanced]
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
-model = "gpt-5.2"
+model = "gpt-5.2-codex"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "concise"
 [profiles.balanced.features]
@@ -49,7 +49,7 @@ web_search_request = true
 [profiles.safe]
 approval_policy = "on-failure"
 sandbox_mode = "read-only"
-model = "gpt-5.2"
+model = "gpt-5.2-codex"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "concise"
 [profiles.safe.features]
@@ -58,7 +58,7 @@ web_search_request = false
 [profiles.yolo]
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
-model = "gpt-5.2"
+model = "gpt-5.2-codex"
 model_reasoning_effort = "high"
 model_reasoning_summary = "detailed"
 [profiles.yolo.features]


### PR DESCRIPTION
## Summary
- Update default Codex model from `gpt-5.2` to `gpt-5.2-codex` across all profiles (balanced, safe, yolo) and documentation
- Add automatic migration for deprecated `enable_experimental_windows_sandbox` → `[features].experimental_windows_sandbox`
- Add automatic migration for legacy root-level feature flags (`experimental_use_exec_command_tool`, `experimental_use_unified_exec_tool`, `experimental_use_rmcp_client`, `include_apply_patch_tool`) into their `[features]` equivalents

## Test plan
- [x] Unit tests added for all migration scenarios
- [ ] Run `vitest --run` to verify tests pass
- [ ] Test `./bin/codex-1up install --dry-run` on macOS