### PR TITLE
chore: move pnpm-only npmrc settings to workspace

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shared-workspace-lockfile=true
-prefer-workspace-packages=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - "cli"
+
+# Keep pnpm-specific settings here (instead of .npmrc) so npm doesn't warn on unknown config keys.
+preferWorkspacePackages: true
+sharedWorkspaceLockfile: true


### PR DESCRIPTION
Removes pnpm-only keys from .npmrc (which trigger npm 11 warnings) and configures them in pnpm-workspace.yaml instead.