### PR TITLE
fix: align codex-1up with codex cli 0.104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Defaults: update the Safe profile to `approval_policy = "untrusted"` (Codex marks `on-failure` as deprecated).
 - Defaults: switch installer-written profiles and template to `model = "gpt-5.3-codex"` (Balanced uses `model_reasoning_effort = "high"`).
 - Template: align comments and defaults to Codex CLI (codex-rs) v0.102 config keys.
+- Template/installer docs: refresh Codex schema/version references to v0.104.
 
 ### Fixed
 - CLI: accept `--profiles-scope selected`.
@@ -21,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Installer: avoid silently ignoring `--experimental` feature toggles when no profiles are being written (fallback to root `[features]`).
 - Installer: validate generated `config.toml` as TOML before writing (avoid producing unparsable configs).
 - Config: remove legacy/removed sandbox flags (`enable_experimental_windows_sandbox`, `experimental_windows_sandbox`) during patching.
-- Config: prune removed feature keys (`search_tool`, `request_rule`, `experimental_windows_sandbox`, `elevated_windows_sandbox`, `include_apply_patch_tool`) from patched configs.
+- Config: prune removed feature keys (`search_tool`, `request_rule`, `experimental_windows_sandbox`, `elevated_windows_sandbox`, `remote_models`, `include_apply_patch_tool`) from patched configs.
 - Doctor: detect legacy `collab`, removed feature keys, and deprecated web-search feature keys; report effective `web_search` and `multi_agent` sources.
 - Template: document `responses_websockets_v2` (under-development) feature flag.
 

--- a/cli/src/flows/installWizard.ts
+++ b/cli/src/flows/installWizard.ts
@@ -359,7 +359,7 @@ export async function runInstallWizard(input: InstallWizardInput): Promise<Insta
     profileMode = modeResponse
   }
 
-  // --- Advanced config options (Codex v0.102 config keys) -------------------
+  // --- Advanced config options (Codex v0.104 config keys) -------------------
 
   if (selectedProfiles.length > 0 && !cliArgs.webSearchArg) {
     p.log.info('Note: this overrides profiles.<name>.web_search for the profiles you are writing. Root web_search is unchanged (fallback only).')

--- a/cli/src/installers/writeCodexConfig.ts
+++ b/cli/src/installers/writeCodexConfig.ts
@@ -563,7 +563,7 @@ function formatTableSeparator(text: string): string {
 }
 
 function migrateExperimentalWindowsSandboxFlag(toml: string): { toml: string; changed: boolean } {
-  // In Codex v0.102 these keys are removed; strip them instead of migrating.
+  // These sandbox feature keys are removed in current Codex releases; strip them instead of migrating.
   const OLD_KEY = 'enable_experimental_windows_sandbox'
   const NEW_KEY = 'experimental_windows_sandbox'
 
@@ -859,6 +859,7 @@ function pruneRemovedFeatureFlags(toml: string): { toml: string; changed: boolea
     'request_rule',
     'experimental_windows_sandbox',
     'elevated_windows_sandbox',
+    'remote_models',
     'include_apply_patch_tool'
   ]
 

--- a/cli/tests/config.patch.behavior.test.ts
+++ b/cli/tests/config.patch.behavior.test.ts
@@ -282,16 +282,19 @@ describe('writeCodexConfig targeted patches', () => {
   it('prunes removed feature keys from root and feature tables', async () => {
     const initial = [
       'search_tool = true',
+      'remote_models = true',
       '',
       '[features]',
       'search_tool = true',
       'request_rule = true',
       'experimental_windows_sandbox = true',
       'elevated_windows_sandbox = true',
+      'remote_models = true',
       'unified_exec = false',
       '',
       '[profiles.safe.features]',
       'search_tool = true',
+      'remote_models = true',
       'apps = true',
       ''
     ].join('\n')
@@ -303,6 +306,7 @@ describe('writeCodexConfig targeted patches', () => {
     expect(data).not.toMatch(/\brequest_rule\s*=/)
     expect(data).not.toMatch(/\bexperimental_windows_sandbox\s*=/)
     expect(data).not.toMatch(/\belevated_windows_sandbox\s*=/)
+    expect(data).not.toMatch(/\bremote_models\s*=/)
     expect(data).toMatch(/\[features\][\s\S]*unified_exec\s*=\s*false/)
     expect(data).toMatch(/\[profiles\.safe\.features\][\s\S]*apps\s*=\s*true/)
     await cleanup()

--- a/cli/tests/config.template.schema.test.ts
+++ b/cli/tests/config.template.schema.test.ts
@@ -101,7 +101,7 @@ function assertKeysAllowed(obj: Record<string, unknown>, allowed: Set<string>, c
 }
 
 describe('templates/codex-config.toml schema guard', () => {
-  it('only uses keys present in codex-rs v0.102 config schema', async () => {
+  it('only uses keys present in codex-rs v0.104 config schema', async () => {
     const repoRoot = resolve(__dirname, '../../')
     const templatePath = resolve(repoRoot, 'templates', 'codex-config.toml')
     const raw = await fs.readFile(templatePath, 'utf8')

--- a/cli/tests/doctor.script.output.test.ts
+++ b/cli/tests/doctor.script.output.test.ts
@@ -35,16 +35,20 @@ describe('doctor script output', () => {
       '',
       '[profiles.safe.features]',
       'search_tool = true',
+      'remote_models = true',
       'web_search_cached = true',
       '',
       '[features]',
       'request_rule = true',
+      'remote_models = true',
       ''
     ].join('\n'))
 
     expect(output).toContain('✔ web_search = cached (profiles.balanced.web_search)')
     expect(output).toContain("⚠ removed feature key 'search_tool' detected at profiles.safe.features.search_tool; remove it")
     expect(output).toContain("⚠ removed feature key 'request_rule' detected at features.request_rule; remove it")
+    expect(output).toContain("⚠ removed feature key 'remote_models' detected at profiles.safe.features.remote_models; remove it")
+    expect(output).toContain("⚠ removed feature key 'remote_models' detected at features.remote_models; remove it")
     expect(output).toContain("ℹ deprecated feature key 'web_search_cached' set at profiles.safe.features.web_search_cached; prefer profiles.safe.web_search")
   })
 
@@ -107,4 +111,3 @@ describe('doctor script output', () => {
     }
   })
 })
-

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -168,7 +168,7 @@ if [ -f "$CFG" ]; then
     echo "⚠ legacy feature key 'collab' detected; migrate to 'multi_agent'"
   fi
 
-  removed_feature_keys=(search_tool request_rule experimental_windows_sandbox elevated_windows_sandbox include_apply_patch_tool)
+  removed_feature_keys=(search_tool request_rule experimental_windows_sandbox elevated_windows_sandbox remote_models include_apply_patch_tool)
   for key in "${removed_feature_keys[@]}"; do
     removed_root="$(toml_table_value "features" "$key" "$CFG")"
     while IFS= read -r profile_name; do

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -1,7 +1,7 @@
 # ~/.codex/config.toml — created by codex-1up
 # Adjust to your liking. See Codex CLI docs for full options.
 #
-# This template is aligned to Codex CLI (codex-rs) v0.102 config keys.
+# This template is aligned to Codex CLI (codex-rs) v0.104 config keys.
 
 # Core (root defaults)
 model = "gpt-5.3-codex"


### PR DESCRIPTION
## Why
- Keep codex-1up release/docs references aligned with the latest stable Codex CLI (`0.104.0`).
- Prevent stale removed feature flags (`remote_models`) from persisting in patched configs.

## How
- Updated Codex version references from `v0.102` to `v0.104` in installer/template schema-reference text.
- Extended removed-feature pruning and doctor reporting to include `remote_models`.
- Added regression coverage for `remote_models` in config patching and doctor script output tests, and updated `CHANGELOG.md` unreleased notes.

## Tests
- `shellcheck scripts/doctor.sh`
- `pnpm -C cli test:run`
