### PR TITLE
Add MiniMax provider presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ codex-1up install
 
 Switch profiles anytime: `codex --profile <name>` for a session, or `codex-1up config set-profile <name>` to persist.
 
+### MiniMax profiles
+
+Set `MINIMAX_API_KEY`, then select a regional model profile:
+
+| Profile | Model | Endpoint |
+| --- | --- | --- |
+| `minimax-global-m3` | `MiniMax-M3` | `https://api.minimax.io/v1` |
+| `minimax-global-m2-7` | `MiniMax-M2.7` | `https://api.minimax.io/v1` |
+| `minimax-cn-m3` | `MiniMax-M3` | `https://api.minimaxi.com/v1` |
+| `minimax-cn-m2-7` | `MiniMax-M2.7` | `https://api.minimaxi.com/v1` |
+
+For example: `codex --profile minimax-global-m3`.
+
 ## Global guidance with AGENTS.md (optional)
 
 You can keep a global guidance file at `~/.codex/AGENTS.md` that Codex will use across projects. During install, you'll be prompted to create this; if you skip, you can create it later:

--- a/cli/src/installers/writeCodexConfig.ts
+++ b/cli/src/installers/writeCodexConfig.ts
@@ -49,6 +49,44 @@ const PROFILE_DEFAULTS: Record<Profile, ProfileDefaults> = {
   }
 }
 
+const MINIMAX_PROVIDER_PRESETS: Record<string, Array<[string, string]>> = {
+  minimax_global: [
+    ['name', '"MiniMax (Global)"'],
+    ['base_url', '"https://api.minimax.io/v1"'],
+    ['env_key', '"MINIMAX_API_KEY"'],
+    ['wire_api', '"responses"']
+  ],
+  minimax_cn: [
+    ['name', '"MiniMax (China)"'],
+    ['base_url', '"https://api.minimaxi.com/v1"'],
+    ['env_key', '"MINIMAX_API_KEY"'],
+    ['wire_api', '"responses"']
+  ]
+}
+
+const MINIMAX_PROFILE_PRESETS: Record<string, Array<[string, string]>> = {
+  'minimax-global-m3': [
+    ['model', '"MiniMax-M3"'],
+    ['model_provider', '"minimax_global"'],
+    ['model_context_window', '1000000']
+  ],
+  'minimax-global-m2-7': [
+    ['model', '"MiniMax-M2.7"'],
+    ['model_provider', '"minimax_global"'],
+    ['model_context_window', '204800']
+  ],
+  'minimax-cn-m3': [
+    ['model', '"MiniMax-M3"'],
+    ['model_provider', '"minimax_cn"'],
+    ['model_context_window', '1000000']
+  ],
+  'minimax-cn-m2-7': [
+    ['model', '"MiniMax-M2.7"'],
+    ['model_provider', '"minimax_cn"'],
+    ['model_context_window', '204800']
+  ]
+}
+
 const HEADER_COMMENT = '# ~/.codex/config.toml — managed by codex-1up (patch mode)\n'
 
 export async function writeCodexConfig(ctx: InstallerContext): Promise<void> {
@@ -70,6 +108,7 @@ export async function writeCodexConfig(ctx: InstallerContext): Promise<void> {
     prunedRemovedFeatures.changed
 
   touched = migrateModelPersonalityKey(editor) || touched
+  touched = applyMiniMaxPresets(editor) || touched
 
   touched = applyProfile(
     editor,
@@ -117,6 +156,25 @@ export async function writeCodexConfig(ctx: InstallerContext): Promise<void> {
 
   await fs.writeFile(cfgPath, finalContent, 'utf8')
   ctx.logger.ok('Updated ~/.codex/config.toml with requested settings.')
+}
+
+function applyMiniMaxPresets(editor: TomlEditor): boolean {
+  let changed = false
+  for (const [name, fields] of Object.entries(MINIMAX_PROVIDER_PRESETS)) {
+    const table = `model_providers.${name}`
+    editor.ensureTable(table)
+    for (const [key, value] of fields) {
+      changed = editor.setKey(table, key, value, { mode: 'if-missing' }) || changed
+    }
+  }
+  for (const [name, fields] of Object.entries(MINIMAX_PROFILE_PRESETS)) {
+    const table = `profiles.${name}`
+    editor.ensureTable(table)
+    for (const [key, value] of fields) {
+      changed = editor.setKey(table, key, value, { mode: 'if-missing' }) || changed
+    }
+  }
+  return changed
 }
 
 function applyProfile(

--- a/cli/tests/config.patch.behavior.test.ts
+++ b/cli/tests/config.patch.behavior.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
+import * as TOML from 'toml'
 import type { InstallerContext, InstallerOptions, Logger } from '../src/installers/types'
 import { writeCodexConfig } from '../src/installers/writeCodexConfig'
 
@@ -54,6 +55,22 @@ async function setupContext(initial: string) {
 }
 
 describe('writeCodexConfig targeted patches', () => {
+  it('adds MiniMax presets without replacing an existing provider URL', async () => {
+    const initial = `[model_providers.minimax_global]\nbase_url = "https://custom.minimax.invalid/v1"\n`
+    const { ctx, cfgPath, cleanup } = await setupContext(initial)
+    ctx.options.profile = 'skip'
+    await writeCodexConfig(ctx)
+    const data = TOML.parse(await fs.readFile(cfgPath, 'utf8')) as any
+
+    expect(data.model_providers.minimax_global.base_url).toBe('https://custom.minimax.invalid/v1')
+    expect(data.model_providers.minimax_global.env_key).toBe('MINIMAX_API_KEY')
+    expect(data.model_providers.minimax_global.wire_api).toBe('responses')
+    expect(data.model_providers.minimax_cn.base_url).toBe('https://api.minimaxi.com/v1')
+    expect(data.profiles['minimax-global-m3'].model).toBe('MiniMax-M3')
+    expect(data.profiles['minimax-cn-m2-7'].model_context_window).toBe(204800)
+    await cleanup()
+  })
+
   it('adds missing profile keys in add mode without removing custom values', async () => {
     const initial = `# existing config\n[profiles.balanced]\napproval_policy = "custom"\n\n`
     const { ctx, cfgPath, cleanup } = await setupContext(initial)

--- a/cli/tests/config.template.schema.test.ts
+++ b/cli/tests/config.template.schema.test.ts
@@ -22,6 +22,7 @@ const ROOT_KEYS = new Set([
   'tui',
   'tools',
   'features',
+  'model_providers',
   'profiles'
 ])
 
@@ -51,6 +52,8 @@ const TUI_KEYS = new Set([
 ])
 
 const TOOLS_KEYS = new Set(['view_image', 'web_search'])
+
+const MODEL_PROVIDER_KEYS = new Set(['name', 'base_url', 'env_key', 'wire_api'])
 
 const FEATURES_KEYS = new Set([
   'undo',
@@ -87,6 +90,8 @@ const PROFILE_KEYS = new Set([
   'approval_policy',
   'sandbox_mode',
   'model',
+  'model_provider',
+  'model_context_window',
   'model_reasoning_effort',
   'model_reasoning_summary',
   'web_search',
@@ -127,6 +132,14 @@ describe('templates/codex-config.toml schema guard', () => {
 
     if (data.tools && typeof data.tools === 'object') {
       assertKeysAllowed(data.tools as Record<string, unknown>, TOOLS_KEYS, 'tools')
+    }
+
+    if (data.model_providers && typeof data.model_providers === 'object') {
+      const providers = data.model_providers as Record<string, unknown>
+      for (const [name, value] of Object.entries(providers)) {
+        expect(typeof value).toBe('object')
+        assertKeysAllowed(value as Record<string, unknown>, MODEL_PROVIDER_KEYS, `model_providers.${name}`)
+      }
     }
 
     if (data.features && typeof data.features === 'object') {

--- a/cli/tests/config.write.test.ts
+++ b/cli/tests/config.write.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { runCommand } from 'citty'
+import * as TOML from 'toml'
 import { root } from '../src/index'
 
 const td = join(tmpdir(), `codex-1up-test-${Date.now()}`)
@@ -29,5 +30,43 @@ describe('config init/write', () => {
     const data = await fs.readFile(CFG, 'utf8')
     expect(data).toMatch(/^show_raw_agent_reasoning\s*=\s*true/m)
     expect(data).toMatch(/^hide_agent_reasoning\s*=\s*false/m)
+  })
+
+  it('writes MiniMax providers and regional model profiles', async () => {
+    await runCommand(root, { rawArgs: ['config', 'init', '--force'] })
+    const data = TOML.parse(await fs.readFile(CFG, 'utf8')) as any
+
+    expect(data.model_providers.minimax_global).toEqual({
+      name: 'MiniMax (Global)',
+      base_url: 'https://api.minimax.io/v1',
+      env_key: 'MINIMAX_API_KEY',
+      wire_api: 'responses'
+    })
+    expect(data.model_providers.minimax_cn).toEqual({
+      name: 'MiniMax (China)',
+      base_url: 'https://api.minimaxi.com/v1',
+      env_key: 'MINIMAX_API_KEY',
+      wire_api: 'responses'
+    })
+    expect(data.profiles['minimax-global-m3']).toMatchObject({
+      model: 'MiniMax-M3',
+      model_provider: 'minimax_global',
+      model_context_window: 1000000
+    })
+    expect(data.profiles['minimax-global-m2-7']).toMatchObject({
+      model: 'MiniMax-M2.7',
+      model_provider: 'minimax_global',
+      model_context_window: 204800
+    })
+    expect(data.profiles['minimax-cn-m3']).toMatchObject({
+      model: 'MiniMax-M3',
+      model_provider: 'minimax_cn',
+      model_context_window: 1000000
+    })
+    expect(data.profiles['minimax-cn-m2-7']).toMatchObject({
+      model: 'MiniMax-M2.7',
+      model_provider: 'minimax_cn',
+      model_context_window: 204800
+    })
   })
 })

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -80,6 +80,20 @@ view_image = true
 # personality = false     # Enable personality selection UI (requires restart)
 # collaboration_modes = false # Enable collaboration mode switching (requires restart)
 
+# ---- MiniMax providers -----------------------------------------------------
+
+[model_providers.minimax_global]
+name = "MiniMax (Global)"
+base_url = "https://api.minimax.io/v1"
+env_key = "MINIMAX_API_KEY"
+wire_api = "responses"
+
+[model_providers.minimax_cn]
+name = "MiniMax (China)"
+base_url = "https://api.minimaxi.com/v1"
+env_key = "MINIMAX_API_KEY"
+wire_api = "responses"
+
 # ---- Profiles (override only what differs from root) -----------------------
 
 [profiles.balanced]
@@ -107,3 +121,24 @@ model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 model_reasoning_summary = "detailed"
 web_search = "live"
+
+# MiniMax profiles inherit the root approval and sandbox settings.
+[profiles.minimax-global-m3]
+model = "MiniMax-M3"
+model_provider = "minimax_global"
+model_context_window = 1000000
+
+[profiles.minimax-global-m2-7]
+model = "MiniMax-M2.7"
+model_provider = "minimax_global"
+model_context_window = 204800
+
+[profiles.minimax-cn-m3]
+model = "MiniMax-M3"
+model_provider = "minimax_cn"
+model_context_window = 1000000
+
+[profiles.minimax-cn-m2-7]
+model = "MiniMax-M2.7"
+model_provider = "minimax_cn"
+model_context_window = 204800


### PR DESCRIPTION
Reason: Add MiniMax regional provider presets to the managed Codex configuration.

- Add global and China provider tables using the MiniMax API key environment variable and Responses API transport.
- Add regional profiles for the supported MiniMax text models and their context windows.
- Preserve existing provider values when patching an existing configuration.
- Document how to select the new profiles.

Checks:
- `pnpm --filter ./cli test:run -- tests/config.template.schema.test.ts tests/config.write.test.ts tests/config.patch.behavior.test.ts`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
